### PR TITLE
ngiab_data_cli v4.6.5 to make sure latest bug fixes are available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -244,7 +244,6 @@ RUN uv venv --system-site-packages \
           /ngen/ngen/extern/lstm --extra-index-url https://download.pytorch.org/whl/cpu \
     && uv pip install --no-cache-dir \
     /tmp/*.whl \
-    #netCDF4==1.6.3 \
     'netCDF4>=1.6.5' \
     numpy==$(/dmod/bin/ngen --info | grep -m 1 -e 'NumPy Version: ' | cut -d ':' -f 2 | uniq | xargs) \
     'pydantic<2' \
@@ -256,7 +255,7 @@ RUN uv venv --system-site-packages \
     # Setup and install ngiab_data_preprocess module to allow preparing data for ngiab
     #   - [Optional] Download default hydrofabric for ngiab_data_preprocess
     #---------------------------------------------
-    ngiab_data_preprocess==4.2.* \
+    ngiab_data_preprocess==4.6.5 \
     #&& uv run python -c "from data_sources.source_validation import download_and_update_hf; \
     #			 download_and_update_hf();" \
     && rm -rf /tmp/*.whl


### PR DESCRIPTION
`ngiab_data_cli` was generating faulty output when creating forcings. The bug was fixed in the latest version which needed to be updated in production.

## Changes

- ngiab_data_cli v4.6.5 to make sure latest bug fixes are available

## Testing

1. Tested on local and 2i2c staging

## Screenshots
<img width="1352" height="878" alt="Screenshot 2025-11-17 at 2 04 01 PM" src="https://github.com/user-attachments/assets/33b19917-d624-45a2-a4f3-b10499d40f19" />
<img width="1352" height="878" alt="Screenshot 2025-11-17 at 2 09 08 PM" src="https://github.com/user-attachments/assets/55fac11d-9433-41d0-b762-94b0c225019b" />

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
