### PR TITLE
Add smoke tests to CI workflow

### DIFF
--- a/.github/workflows/nextgen_build.yaml
+++ b/.github/workflows/nextgen_build.yaml
@@ -80,4 +80,36 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
+          load: ${{ github.event_name == 'pull_request' }}
           tags: quay.io/${{ env.QUAY_ORG }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.value }}
+
+      - name: Run smoke tests
+        id: smoke-tests
+        if: github.event_name == 'pull_request'
+        timeout-minutes: 30
+        run: |
+          IMAGE="quay.io/${{ env.QUAY_ORG }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.value }}"
+          docker run --rm "$IMAGE" /tests/test-entrypoint.sh 2>&1 | tee /tmp/test-results.log
+          echo "result=pass" >> "$GITHUB_OUTPUT"
+
+      - name: Comment test results on PR
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let log = '';
+            try {
+              log = fs.readFileSync('/tmp/test-results.log', 'utf8');
+            } catch (e) {
+              log = 'No test output captured.';
+            }
+            const passed = '${{ steps.smoke-tests.outcome }}' === 'success';
+            const status = passed ? 'PASSED: Smoke tests' : 'FAILED: Smoke tests';
+            const body = `## ${status}\n\n<details><summary>Test output</summary>\n\n\`\`\`\n${log.slice(-3000)}\n\`\`\`\n\n</details>`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body
+            });

--- a/tests/test-entrypoint.sh
+++ b/tests/test-entrypoint.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
+set -eo pipefail
+
 /srv/conda/envs/notebook/bin/python /tests/tests.py -v 2>&1 | tee /tests/pyngiab_tests.log
 # No need to activate the venv since it is done automatically by PyNGIAB
 #source /ngen/.venv/bin/activate && /srv/conda/envs/notebook/bin/python /tests/tests.py -v
 
 # TEEHR(https://github.com/RTIInternational/teehr/) built-in tests
+# Note: TEEHR tests are non-blocking as they depend on external APIs/network
 cd /tests && \
     git init teehr \
     && cd teehr \
@@ -13,4 +16,4 @@ cd /tests && \
     && echo "tests/" >> .git/info/sparse-checkout \
     && git pull origin main
 # Tests need to be executed from a specific directory (Thanks to Matt from RTI for the help)
-cd /tests/teehr/ && /srv/conda/envs/notebook/bin/pytest tests/ 2>&1 | tee /tests/teehr_tests.log
+cd /tests/teehr/ && /srv/conda/envs/notebook/bin/pytest tests/ 2>&1 | tee /tests/teehr_tests.log || echo "WARNING: TEEHR tests failed (non-blocking)"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 
 class TestJupyter(unittest.TestCase):
@@ -9,35 +10,40 @@ class TestJupyter(unittest.TestCase):
                                 shell=True,
                                 check=True)
         self.assertEqual(result.returncode, 0)
-        self.assertIn('jupyter_server   : 2.13.0', result.stdout)
-        self.assertIn('jupyterlab       :', result.stdout)
+        self.assertIn('jupyter_server', result.stdout)
+        self.assertIn('jupyterlab', result.stdout)
         pass
 
     pass
 
 if __name__ == '__main__':
-    #unittest.main(exit=False)
-    #unittest.main(TestPyNGIAB(), exit=False)
-    #unittest.main(TestNGIABDataPreprocess(), exit=False)
+    failed = False
 
     ''' Test cases to make sure `ngen` and utilities are available in commandline '''
     ngiab_cmd_tests = unittest.TestLoader().discover('.', pattern = 'test_ngiab_cmd*.py')
-    unittest.TextTestRunner(verbosity=1).run(ngiab_cmd_tests)
+    result = unittest.TextTestRunner(verbosity=1).run(ngiab_cmd_tests)
+    if not result.wasSuccessful():
+        failed = True
 
     ''' Test cases for PyNGIAB module '''
     pyngiab_tests = unittest.TestLoader().discover('.', pattern = 'test_pyngiab*.py')
-    unittest.TextTestRunner(verbosity=1).run(pyngiab_tests)
-    
+    result = unittest.TextTestRunner(verbosity=1).run(pyngiab_tests)
+    if not result.wasSuccessful():
+        failed = True
+
     ''' Test cases for data preprocessing via ngiab_data_cli module '''
     ngiab_data_preprocess_tests = unittest.TestLoader().discover('.',
                                                                  pattern = 'test_ngiab_data*.py')
-    unittest.TextTestRunner(verbosity=1).run(ngiab_data_preprocess_tests)
+    result = unittest.TextTestRunner(verbosity=1).run(ngiab_data_preprocess_tests)
+    if not result.wasSuccessful():
+        failed = True
 
     ''' Test cases for TEEHR module (https://github.com/RTIInternational/teehr/)
     Note: TEEHR has its own test cases which are invoked from commandline
     Please see /tests/test-entrypoint.sh
     '''
     # teehr_tests = unittest.TestLoader().discover('.', pattern = 'test_pyngiab*.py')
-    # unittest.TextTestRunner(verbosity=1).run(teehr_tests)
-    
-    pass
+    # result = unittest.TextTestRunner(verbosity=1).run(teehr_tests)
+
+    if failed:
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- Wire up existing tests (`/tests/test-entrypoint.sh`) to run after image build on PRs
- Fix `tests.py` to exit non-zero on test failure (was silently passing)
- Remove hardcoded `jupyter_server` version check (was brittle across upgrades)
- Add `set -eo pipefail` to `test-entrypoint.sh` so failures piped through `tee` are caught
- Make TEEHR tests non-blocking since they depend on external APIs
- Post test results as a comment on the PR with collapsible output
- Add 30-minute timeout to smoke test step to prevent hangs

## Verification
- Temporarily removed the pandas pin and confirmed the smoke tests correctly failed with the `Unhandled feature datatype` error
- Restored the pin and confirmed CI passes

## Test plan
- [x] CI passes with pandas pin in place
- [x] CI fails when pandas pin is removed (proves tests catch real issues)
- [x] TEEHR test failures don't block the pipeline
- [x] Test results are posted as PR comments