### PR TITLE
Add `cartopy` package to environment for CUAHSI DevCon26 workshop

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,4 +29,5 @@ dependencies:
   - zarr=3.1.6=pyhc364b38_0
   - pip
   - pip:
+    - cartopy==0.25.0
     - git+https://github.com/hydroshare/nbfetch.git@v0.6.3


### PR DESCRIPTION
This is a very minor PR adding the `cartopy` package to the `environment.yml` for working with the notebooks in [this HydroShare collection](https://www.hydroshare.org/resource/97e4d2c92e304268ade8dd7f8b616727/) for the CUAHSI workshop at DevCon26. 

I mistakenly omitted this from the configuration file sent in [this issue thread](https://github.com/issues/assigned?issue=CIROH-UA%7CNGIAB-CloudInfra%7C458). 