### PR TITLE
Update Dockerfile to use Node 22.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get -y update \
  && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js and npm
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs
 
 # Install TurboVNC (https://github.com/TurboVNC/turbovnc)


### PR DESCRIPTION
Upgrades the main branch to Node 22, in accordance with the [Node.js release schedule](https://nodejs.org/en/about/previous-releases).

Currently, the Dockerfile for the main branch uses Node 16.x, which was deprecated a while ago. This seems to have finally caught up with us, as some of our dependencies now explicitly _prohibit_ the use of Node 16. See [here](https://github.com/CIROH-UA/awi-ciroh-image/actions/runs/28259645441) for an example of this failing.

This has been confirmed to fix the CI/CD process via the podman branch ([action run](https://github.com/CIROH-UA/awi-ciroh-image/actions/runs/29335309920)).